### PR TITLE
Using DockerHub Image instead of building

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,19 @@
 
 (with reflex)
 
-1. make satysfi
-2. make dev
-3. access `http://loacalhost:8888`
+1. make dev
+2. access `http://loacalhost:8888`
 
 (without reflex)
-1. make satysfi
-2. make build
-3. PORT=8888 make run
-4. access `http://loacalhost:8888`
+1. make build
+2. PORT=8888 make run
+3. access `http://loacalhost:8888`
 
+**NOTE**: This tool uses a Docker image for PDF generation. When starting the application local environment, execute the following command before compiling the SATySFi document.
+
+```
+$ docker pull theoldmoon0602/satysfi:latest
+```
 
 ## Directory Structure
 


### PR DESCRIPTION
Clarified that you need to run docker pull in advance.This is because when compiling is executed via the Docker command, an error occurs if the Docker image does not exist.

Maybe it's more helpful to check if the Docker image exists and if it doesn't exist, give an error message. However, I don't feel that I need to do that at this stage.

The tag is set to latest according to the implementation, but please comment if there is a problem.