### PR TITLE
依存パッケージの事前インストールをしていないとビルドが失敗していたのを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,8 @@ ui:
 satysfi:
 	cd SATySFi; \
 	docker build -t satysfi .
+
+.PHONY: setup
+setup:
+	go get github.com/rakyll/statik
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - GNU Make
 - yarn
 - [cespare/reflex](https://github.com/cespare/reflex)
+- [statik](https://github.com/rakyll/statik)
 
 ## How to use
 
@@ -27,9 +28,10 @@
 2. access `http://loacalhost:8888`
 
 (without reflex)
-1. make build
-2. PORT=8888 make run
-3. access `http://loacalhost:8888`
+1. make setup
+2. make build
+3. PORT=8888 make run
+4. access `http://loacalhost:8888`
 
 **NOTE**: This tool uses a Docker image for PDF generation. When starting the application local environment, execute the following command before compiling the SATySFi document.
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,6 +5,7 @@
   "author": "theoremoon",
   "license": "Apache-2.0",
   "devDependencies": {
+    "elm": "^0.19.1-3",
     "node-elm-compiler": "^5.0.4",
     "parcel": "^1.12.4",
     "parcel-plugin-inline-source": "^1.0.0"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1955,6 +1955,13 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+elm@^0.19.1-3:
+  version "0.19.1-3"
+  resolved "https://registry.yarnpkg.com/elm/-/elm-0.19.1-3.tgz#2382aa1943bc79974b5d95b0a6acbe010ee16909"
+  integrity sha512-6y36ewCcVmTOx8lj7cKJs3bhI5qMfoVEigePZ9PhEUNKpwjjML/pU2u2YSpHVAznuCcojoF6KIsrS1Ci7GtVaQ==
+  dependencies:
+    request "^2.88.0"
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"


### PR DESCRIPTION
`git clone` 直後に `make build` したところ `elm` コマンドが入ってなくてビルドができなかったので修正しました